### PR TITLE
ocfs2-tools: add support for vd devices

### DIFF
--- a/o2cb_ctl/o2cb_scandisk.c
+++ b/o2cb_ctl/o2cb_scandisk.c
@@ -130,6 +130,8 @@ static void add_to_list(struct list_head *device_list, struct devnode *node)
 				add = !strncmp(path->path, "/dev/loop", 9);
 			if (!add)
 				add = !strncmp(path->path, "/dev/xvd", 8);
+			if (!add)
+				add = !strncmp(path->path, "/dev/vd", 7);
 		}
 		if (add) {
 			hb = malloc(sizeof(struct hb_devices));


### PR DESCRIPTION
Allow global heartbeat on /dev/vd Virtio devices inside KVM.
This is equivalent to /dev/xvd device support previously added for Xen.