### PR TITLE
Update udev rule for newer kernels

### DIFF
--- a/vendor/common/51-ocfs2.rules
+++ b/vendor/common/51-ocfs2.rules
@@ -1,2 +1,1 @@
-KERNEL=="ocfs2_control", NAME="misc/ocfs2_control", MODE="0660"
-
+KERNEL=="ocfs2_control", SYMLINK+="misc/ocfs2_control", MODE="0660"


### PR DESCRIPTION
Fixes udev warning:
NAME="misc/ocfs2_control" ignored, kernel device nodes can not be renamed