### PR TITLE
Update sysfs filename for heartbeat dead threshold

### DIFF
--- a/o2monitor/o2hbmonitor.c
+++ b/o2monitor/o2hbmonitor.c
@@ -49,7 +49,7 @@
 #define SYS_CONFIG_DIR			"/sys/kernel/config"
 #define O2HB_CLUSTER_DIR		SYS_CONFIG_DIR"/cluster"
 #define O2HB_HEARTBEAT_DIR		O2HB_CLUSTER_DIR"/%s/heartbeat"
-#define O2HB_DEAD_THRESHOLD		O2HB_HEARTBEAT_DIR"/dead_threshold"
+#define O2HB_DEAD_THRESHOLD		O2HB_HEARTBEAT_DIR"/threshold"
 #define O2HB_DEVICE			O2HB_HEARTBEAT_DIR"/%s/dev"
 
 #define SYS_DEBUG_DIR			"/sys/kernel/debug"

--- a/vendor/common/o2cb.init.sh
+++ b/vendor/common/o2cb.init.sh
@@ -235,7 +235,7 @@ read_timeout()
 set_timeouts_o2cb()
 {
     O2CB_HEARTBEAT_THRESHOLD_FILE_OLD=/proc/fs/ocfs2_nodemanager/hb_dead_threshold
-    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/dead_threshold
+    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/threshold
     if [ -n "$O2CB_HEARTBEAT_THRESHOLD" ]; then
         if [ -f "$O2CB_HEARTBEAT_THRESHOLD_FILE" ]; then
             echo "$O2CB_HEARTBEAT_THRESHOLD" > "$O2CB_HEARTBEAT_THRESHOLD_FILE"
@@ -270,7 +270,7 @@ show_timeouts_o2cb()
 {
 
     O2CB_HEARTBEAT_THRESHOLD_FILE_OLD=/proc/fs/ocfs2_nodemanager/hb_dead_threshold
-    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/dead_threshold
+    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/threshold
     if [ -f "$O2CB_HEARTBEAT_THRESHOLD_FILE" ]; then
         VAL=`cat "$O2CB_HEARTBEAT_THRESHOLD_FILE"`
         echo "  Heartbeat dead threshold: ${VAL}"


### PR DESCRIPTION
This was changed in the kernel a while ago so the heartbeat config currently looks like this (kernel 4.9.13):
```
$ ls -l /sys/kernel/config/cluster/ocfs2/heartbeat
drwxr-xr-x 2 root root    0 Mar 24 18:53 00831BDF77A04E4EBB619359FE5A4CAA
-rw-r--r-- 1 root root 4096 Mar 24 19:19 mode
-rw-r--r-- 1 root root 4096 Mar 24 19:19 threshold
```