### PR TITLE
Revert "Update sysfs filename for heartbeat dead threshold"

### DIFF
--- a/o2monitor/o2hbmonitor.c
+++ b/o2monitor/o2hbmonitor.c
@@ -49,7 +49,7 @@
 #define SYS_CONFIG_DIR			"/sys/kernel/config"
 #define O2HB_CLUSTER_DIR		SYS_CONFIG_DIR"/cluster"
 #define O2HB_HEARTBEAT_DIR		O2HB_CLUSTER_DIR"/%s/heartbeat"
-#define O2HB_DEAD_THRESHOLD		O2HB_HEARTBEAT_DIR"/threshold"
+#define O2HB_DEAD_THRESHOLD		O2HB_HEARTBEAT_DIR"/dead_threshold"
 #define O2HB_DEVICE			O2HB_HEARTBEAT_DIR"/%s/dev"
 
 #define SYS_DEBUG_DIR			"/sys/kernel/debug"

--- a/vendor/common/o2cb.init.sh
+++ b/vendor/common/o2cb.init.sh
@@ -235,7 +235,7 @@ read_timeout()
 set_timeouts_o2cb()
 {
     O2CB_HEARTBEAT_THRESHOLD_FILE_OLD=/proc/fs/ocfs2_nodemanager/hb_dead_threshold
-    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/threshold
+    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/dead_threshold
     if [ -n "$O2CB_HEARTBEAT_THRESHOLD" ]; then
         if [ -f "$O2CB_HEARTBEAT_THRESHOLD_FILE" ]; then
             echo "$O2CB_HEARTBEAT_THRESHOLD" > "$O2CB_HEARTBEAT_THRESHOLD_FILE"
@@ -270,7 +270,7 @@ show_timeouts_o2cb()
 {
 
     O2CB_HEARTBEAT_THRESHOLD_FILE_OLD=/proc/fs/ocfs2_nodemanager/hb_dead_threshold
-    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/threshold
+    O2CB_HEARTBEAT_THRESHOLD_FILE=$(configfs_path)/cluster/${CLUSTER}/heartbeat/dead_threshold
     if [ -f "$O2CB_HEARTBEAT_THRESHOLD_FILE" ]; then
         VAL=`cat "$O2CB_HEARTBEAT_THRESHOLD_FILE"`
         echo "  Heartbeat dead threshold: ${VAL}"


### PR DESCRIPTION
Reverts markfasheh/ocfs2-tools#9

This is a kernel issue, fix from kernel side.