### PR TITLE
fix bug that debugfs dose not do ecc check if necessary

### DIFF
--- a/debugfs.ocfs2/commands.c
+++ b/debugfs.ocfs2/commands.c
@@ -690,7 +690,7 @@ static void do_open(char **args)
 	}
 
 	flags = gbls.allow_write ? OCFS2_FLAG_RW : OCFS2_FLAG_RO;
-        flags |= OCFS2_FLAG_HEARTBEAT_DEV_OK|OCFS2_FLAG_NO_ECC_CHECKS;
+	flags |= OCFS2_FLAG_HEARTBEAT_DEV_OK | OCFS2_FLAG_NO_ECC_CHECKS;
 	if (gbls.imagefile)
 		flags |= OCFS2_FLAG_IMAGE_FILE;
 
@@ -702,6 +702,11 @@ static void do_open(char **args)
 			dev);
 		return ;
 	}
+	
+	if (OCFS2_HAS_INCOMPAT_FEATURE(OCFS2_RAW_SB(gbls.fs->fs_super),
+				OCFS2_FEATURE_INCOMPAT_META_ECC))
+		gbls.fs->fs_flags &= ~OCFS2_FLAG_NO_ECC_CHECKS;
+
 
 	/* allocate blocksize buffer */
 	ret = ocfs2_malloc_block(gbls.fs->fs_io, &gbls.blockbuf);

--- a/mkfs.ocfs2/mkfs.h
+++ b/mkfs.ocfs2/mkfs.h
@@ -41,6 +41,7 @@
 #include <inttypes.h>
 #include <ctype.h>
 #include <assert.h>
+#include <sys/ioctl.h>
 
 #include <uuid/uuid.h>
 
@@ -91,6 +92,14 @@
 #define CLUSTERS_MAX           (UINT32_MAX - 1)
 
 #define MAX_EXTALLOC_RESERVE_PERCENT	5
+
+#define DISCARD_STEP_MB         2048
+
+#if defined(__linux__) && !defined(BLKDISCARD)
+#define BLKDISCARD		_IO(0x12,119)
+#endif
+
+
 
 enum {
 	SFI_JOURNAL,
@@ -193,6 +202,7 @@ struct _State {
 	int inline_data;
 	int dx_dirs;
 	int dry_run;
+	int discard_blocks;
 
 	uint32_t blocksize;
 	uint32_t blocksize_bits;

--- a/mkfs.ocfs2/mkfs.ocfs2.8.in
+++ b/mkfs.ocfs2/mkfs.ocfs2.8.in
@@ -2,7 +2,7 @@
 .SH "NAME"
 mkfs.ocfs2 \- Creates an \fIOCFS2\fR file system.
 .SH "SYNOPSIS"
-\fBmkfs.ocfs2\fR [\fB\-b\fR \fIblock\-size\fR] [\fB\-C\fR \fIcluster\-size\fR] [\fB\-L\fR \fIvolume\-label\fR] [\fB\-M\fR \fImount-type\fR] [\fB\-N\fR \fInumber\-of\-nodes\fR] [\fB\-J\fR \fIjournal\-options\fR] [\fB\-\-fs\-features=\fR\fI[no]sparse...\fR] [\fB\-\-fs\-feature\-level=\fR\fIfeature\-level\fR] [\fB\-T\fR \fIfilesystem\-type\fR] [\fB\-\-cluster\-stack=\fR\fIstackname\fR] [\fB\-\-cluster\-name=\fR\fIclustername\fR] [\fB\-\-global\-heartbeat\fR] [\fB\-FqvV\fR] \fIdevice\fR [\fIblocks-count\fI]
+\fBmkfs.ocfs2\fR [\fB\-b\fR \fIblock\-size\fR] [\fB\-C\fR \fIcluster\-size\fR] [\fB\-L\fR \fIvolume\-label\fR] [\fB\-M\fR \fImount-type\fR] [\fB\-N\fR \fInumber\-of\-nodes\fR] [\fB\-J\fR \fIjournal\-options\fR] [\fB\-\-fs\-features=\fR\fI[no]sparse...\fR] [\fB\-\-fs\-feature\-level=\fR\fIfeature\-level\fR] [\fB\-T\fR \fIfilesystem\-type\fR] [\fB\-\-cluster\-stack=\fR\fIstackname\fR] [\fB\-\-cluster\-name=\fR\fIclustername\fR] [\fB\-\-global\-heartbeat\fR] [\fB\-\-discard | \-\-nodiscard\fR] [\fB\-FqvV\fR] \fIdevice\fR [\fIblocks-count\fI]
 .SH "DESCRIPTION"
 .PP
 \fBmkfs.ocfs2\fR is used to create an \fIOCFS2\fR file system on a \fIdevice\fR,
@@ -225,6 +225,19 @@ required if the \fBo2cb\fR cluster stack with global heartbeat is online as \fIm
 will detect the active stack. However, if the cluster stack is not up, then this option
 is required alongwith \fIcluster\-stack\fR and \fIcluster\-name\fR.  For more, refer to
 \fBo2cb(7)\fR.
+
+.TP
+\fB\-\-discard\fR
+Attempt to discard blocks at mkfs time (discarding blocks initially is useful
+on solid state devices and sparse / thin-provisioned storage). When the device
+advertises that discard also zeroes data (any subsequent read after the discard
+and before write returns zero), then mark all not-yet-zeroed blocks as
+zeroed. This significantly speeds up filesystem initialization. This is set
+as default.
+
+.TP
+\fB\-\-nodiscard\fR
+Do not attempt to discard blocks at mkfs time.
 
 .TP
 \fB\-\-no-backup-super\fR


### PR DESCRIPTION
If the meta-ecc feature is enabled, when debugfs read some meta data, it does not do ecc check.

So the wrong data that could be actually corrected by hamming encode can not be used by debugfs.