### PR TITLE
mounted.ocfs2: use <sys/sysmacros.h> include for makedev

### DIFF
--- a/mounted.ocfs2/mounted.c
+++ b/mounted.ocfs2/mounted.c
@@ -25,7 +25,7 @@
 #define _LARGEFILE64_SOURCE
 #define _GNU_SOURCE /* Because libc really doesn't want us using O_DIRECT? */
 
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
 mounted.c: In function ‘build_partition_list’:
 mounted.c:354:13: warning: In the GNU C Library, "makedev" is defined
  by <sys/sysmacros.h>. For historical compatibility, it is
  currently defined by <sys/types.h> as well, but we plan to
  remove this soon. To use "makedev", include <sys/sysmacros.h>
  directly. If you did not intend to use a system-defined macro
  "makedev", you should undefine it after including <sys/types.h>.
        makedev(major, minor), &devname);
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~