### PR TITLE
o2cb.init: Fix error printed by service o2cb stop

### DIFF
--- a/vendor/common/o2cb.init.sh
+++ b/vendor/common/o2cb.init.sh
@@ -1148,11 +1148,11 @@ unload_stack_plugins()
     # we have nothing to do.
     [ ! -e "$LOADED_PLUGINS_FILE" ] && return 2
 
-    while read plugin
+    for plugin in $(cat "$LOADED_PLUGINS_FILE")
     do
         unload_module "ocfs2_stack_${plugin}"
         if_fail $? "Unable to unload ocfs2_stack_${plugin}"
-    done <"$LOADED_PLUGINS_FILE"
+    done
 
     unload_module "ocfs2_stackglue"
     if_fail $? "Unable to unload ocfs2_stackglue"


### PR DESCRIPTION
The $LOADED_PLUGINS_FILE disappears after unloading
modules and the read returns an error:

 # service o2cb stop
 ...
 Unloading module "ocfs2_dlmfs": OK
 Unloading module "ocfs2_stack_o2cb": OK
 /usr/lib/ocfs2-tools/o2cb: line 1151: read: read error: 0: No such device