### PR TITLE
Fix spelling in documentation and binary strings

### DIFF
--- a/debugfs.ocfs2/debugfs.ocfs2.8.in
+++ b/debugfs.ocfs2/debugfs.ocfs2.8.in
@@ -48,7 +48,7 @@ Executes a single debugfs command.
 
 .TP
 \fB\-s, \-\-superblock\fR \fIbackup\-number\fR
-\fImkfs.ocfs2\fR makes upto 6 backup copies of the superblock at offsets 1G, 4G,
+\fImkfs.ocfs2\fR makes up to 6 backup copies of the superblock at offsets 1G, 4G,
 16G, 64G, 256G and 1T depending on the size of the volume. Use this option to
 specify the backup, 1 thru 6, to use to open the volume.
 

--- a/fsck.ocfs2/extent.c
+++ b/fsck.ocfs2/extent.c
@@ -300,7 +300,7 @@ errcode_t check_el(o2fsck_state *ost, struct extent_info *ei,
 			   "this record from the extent list?", i, owner)) {
 
 			if (!trust_next_free) {
-				printf("Can't remove the record becuase "
+				printf("Can't remove the record because "
 				       "next_free_rec hasn't been fixed\n");
 				continue;
 			}

--- a/fsck.ocfs2/fsck.c
+++ b/fsck.ocfs2/fsck.c
@@ -226,7 +226,7 @@ errcode_t o2fsck_state_reinit(ocfs2_filesys *fs, o2fsck_state *ost)
 
 	ret = o2fsck_state_init(fs, ost);
 	if (ret) {
-		com_err(whoami, ret, "while intializing o2fsck_state.");
+		com_err(whoami, ret, "while initializing o2fsck_state.");
 		return ret;
 	}
 

--- a/fsck.ocfs2/fsck.ocfs2.8.in
+++ b/fsck.ocfs2/fsck.ocfs2.8.in
@@ -77,7 +77,7 @@ Show progress.
 
 .TP
 \fB\-r\fR \fIbackup-number\fR
-\fImkfs.ocfs2\fR makes upto 6 backup copies of the superblock at offsets
+\fImkfs.ocfs2\fR makes up to 6 backup copies of the superblock at offsets
 1G, 4G, 16G, 64G, 256G and 1T depending on the size of the volume.
 Use this option to specify the backup, 1 thru 6, to use to recover the
 superblock.

--- a/fsck.ocfs2/fsck.ocfs2.checks.8.in
+++ b/fsck.ocfs2/fsck.ocfs2.checks.8.in
@@ -641,7 +641,7 @@ Answering yes remove this flag from the file.
 
 .SS "REFCOUNT_LOC_INVALID"
 Refcount loc can only be valid if the file has refcount flag set. Fsck has
-found that a file has refcount loc while it does't have refcount flag set.
+found that a file has refcount loc while it doesn't have refcount flag set.
 
 Answering yes reset refcount loc to zero for the file.
 
@@ -718,7 +718,7 @@ information is sane.
 
 .SS "REFCOUNT_BLOCK_INVALID"
 Refcount block stores the refcount record for physical clusters of a file.
-It is found refering an invalid refcount block.
+It is found referring an invalid refcount block.
 
 Answering yes remove this refcount block.
 
@@ -732,7 +732,7 @@ of clusters that were associated with the tree.
 
 .SS "REFCOUNT_ROOT_BLOCK_INVALID"
 Root refcount block is the root of the refcount record for a file. It is found
-refering an invalid refcount block.
+referring an invalid refcount block.
 
 Answering yes remove this refcount block and clear refcount flag from this file.
 
@@ -749,9 +749,9 @@ record is found whichs claims the wrong refcount for some physical clusters.
 Answering yes update the corresponding refcount record.
 
 .SS "REFCOUNT_COUNT"
-Refcount tree contains a record of how many files refering to this tree.
+Refcount tree contains a record of how many files referring to this tree.
 A tree was found whose recorded number of files doesn't match the real
-files refering to the tree.
+files referring to the tree.
 
 Answering yes resets the number of files to reflect the real number
 of files that were associated with the tree.

--- a/fsck.ocfs2/pass0.c
+++ b/fsck.ocfs2/pass0.c
@@ -177,7 +177,7 @@ static void check_discontig_bg(o2fsck_state *ost, int cpg,
 	if ((bg->bg_list.l_count >
 	     ocfs2_extent_recs_per_gd(ost->ost_fs->fs_blocksize)) &&
 	    prompt(ost, PY, PR_DISCONTIG_BG_COUNT,
-		   "Discontigous group descriptor at block %"PRIu64" has "
+		   "Discontiguous group descriptor at block %"PRIu64" has "
 		   "an extent count of %u, but discontiguous groups can "
 		   "only hold %u records.  Set it to %u?", blkno,
 		   bg->bg_list.l_count,
@@ -1027,7 +1027,7 @@ static errcode_t verify_chain_alloc(o2fsck_state *ost,
 			   (uint64_t)di->i_blkno)) {
 
 			if (!trust_next_free) {
-				printf("Can't remove the chain becuase "
+				printf("Can't remove the chain because "
 				       "next_free_rec hasn't been fixed\n");
 				continue;
 			}

--- a/fsck.ocfs2/pass1b.c
+++ b/fsck.ocfs2/pass1b.c
@@ -1082,7 +1082,7 @@ static int print_func(struct dup_cluster *dc, struct dup_inode *di,
  * 3. It has the same tree as others.
  * Store refcount_loc if we find one.
  *
- * if there is other file that does't have the same tree, set refcount_loc
+ * if there is other file that doesn't have the same tree, set refcount_loc
  * to UINT64_MAX and stop the search.
  */
 static int find_refcount_func(struct dup_cluster *dc, struct dup_inode *di,

--- a/fsck.ocfs2/pass2.c
+++ b/fsck.ocfs2/pass2.c
@@ -613,7 +613,7 @@ static errcode_t fix_dirent_dups(o2fsck_state *ost,
 
 	if (was_set) {
 		printf("Directory inode %"PRIu64" contains a duplicate "
-		       "occurance " "of the file name '%.*s' but fsck was "
+		       "occurrence " "of the file name '%.*s' but fsck was "
 		       "unable to come up with a unique name so this duplicate "
 		       "name will not be dealt with.\n.",
 			dbe->e_ino, dirent->name_len, dirent->name);
@@ -621,7 +621,7 @@ static errcode_t fix_dirent_dups(o2fsck_state *ost,
 	}
 
 	if (!prompt(ost, PY, PR_DIRENT_DUPLICATE,
-		    "Directory inode %"PRIu64" contains a duplicate occurance "
+		    "Directory inode %"PRIu64" contains a duplicate occurrence "
 		    "of the file name '%.*s'.  Replace this duplicate name "
 		    "with '%s'?", dbe->e_ino, dirent->name_len, dirent->name,
 		    new_name)) {

--- a/fsck.ocfs2/refcount.c
+++ b/fsck.ocfs2/refcount.c
@@ -124,7 +124,7 @@ static void check_rl(o2fsck_state *ost,
 			   "this record from the refcount list?",
 			   i, rb_blkno, root_blkno)) {
 			if (!trust_used) {
-				printf("Can't remove the record becuase "
+				printf("Can't remove the record because "
 				       "rl_used hasn't been fixed\n");
 				continue;
 			}
@@ -139,7 +139,7 @@ static void check_rl(o2fsck_state *ost,
 			   "this record from the refcount list?",
 			   i, rb_blkno, root_blkno)) {
 			if (!trust_used) {
-				printf("Can't remove the record becuase "
+				printf("Can't remove the record because "
 				       "rl_used hasn't been fixed\n");
 				continue;
 			}

--- a/libo2cb/o2cb.7.in
+++ b/libo2cb/o2cb.7.in
@@ -116,7 +116,7 @@ a cluster with 5 regions, a slowdown in 2 will be tolerated.
 It is for this reason, this mode is recommended for users that have 3 or more OCFS2
 mounts.
 
-O2CB allows upto \fB32\fR heartbeat regions to be configured in the global heartbeat mode.
+O2CB allows up to \fB32\fR heartbeat regions to be configured in the global heartbeat mode.
 
 .SH "ONLINE CLUSTER MODIFICATION"
 .PP

--- a/libocfs2/ocfs2.7.in
+++ b/libocfs2/ocfs2.7.in
@@ -281,7 +281,7 @@ cluster. It replaces the older utility \fBo2cb_ctl(8)\fR which has being depreca
 \fBocfs2console(8)\fR has been obsoleted.
 
 \fBo2info(8)\fR is a new utility that can be used to provide file system information.
-It allows non-priviledged users to see the enabled file system features, block and
+It allows non-privileged users to see the enabled file system features, block and
 cluster sizes, extended file stat, free space fragmentation, etc.
 
 \fBo2hbmonitor(8)\fR is a \fBo2hb\fR heartbeat monitor. It is an extremely light weight
@@ -289,7 +289,7 @@ utility that logs messages to the system logger once the heartbeat delay exceeds
 warn threshold. This utility is useful in identifying volumes encountering I/O delays.
 
 \fBdebugfs.ocfs2(8)\fR has some new commands. \fInet_stats\fR shows the \fBo2net\fR
-message times between various nodes. This is useful in indentifying nodes are that slowing
+message times between various nodes. This is useful in identifying nodes are that slowing
 down the cluster operations. \fIstat_sysdir\fR allows the user to dump the entire system
 directory that can be used to debug issues. \fIgrpextents\fR dumps the complete free space
 fragmentation in the cluster group allocator.
@@ -517,7 +517,7 @@ To convert an existing clustered volume to a non-clustered volume, do:
 Non-clustered volumes do not interact with the cluster stack. One can have both
 clustered and non-clustered volumes mounted at the same time.
 
-While formating a non-clustered volume, users should consider the possibility of later
+While formatting a non-clustered volume, users should consider the possibility of later
 converting that volume to a clustered one. If there is a possibility of that, then the
 user should add enough node-slots using the -N option. Adding node-slots during format
 creates journals with large extents. If created later, then the journals will be
@@ -684,7 +684,7 @@ is not in use on any node.
 This is the file system \fIinformation\fR utility. It provides information like the features
 enabled on disk, block size, cluster size, free space fragmentation, etc.
 
-It can be used by both priviledged and non-priviledged users. Users having read permission
+It can be used by both privileged and non-privileged users. Users having read permission
 on the device can provide the path to the device. Other users can provide the path to a
 file on a mounted file system.
 

--- a/libocfs2/ocfs2_err.et
+++ b/libocfs2/ocfs2_err.et
@@ -112,7 +112,7 @@ ec	OCFS2_ET_INVALID_BIT,
 	"Bit does not exist in bitmap range"
 
 ec	OCFS2_ET_INTERNAL_FAILURE,
-	"Internal logic faliure"
+	"Internal logic failure"
 
 ec	OCFS2_ET_BAD_GROUP_DESC_MAGIC,
 	"Bad magic number in group descriptor"

--- a/mkfs.ocfs2/mkfs.ocfs2.8.in
+++ b/mkfs.ocfs2/mkfs.ocfs2.8.in
@@ -145,8 +145,8 @@ Enables creation of reference counted trees. With this enabled, the file system 
 .TP
 \fBxattr\fR
 Enable extended attributes support. With this enabled, users can attach name:value pairs to objects
-within the file system. In \fIOCFS2\fR, the names can be upto 255 bytes in length, terminated by the first
-NUL byte. While it is not required, printable names (ASCII) are recommended. The values can be upto 64KB of
+within the file system. In \fIOCFS2\fR, the names can be up to 255 bytes in length, terminated by the first
+NUL byte. While it is not required, printable names (ASCII) are recommended. The values can be up to 64KB of
 arbitrary binary data. Attributes can be attached to all types of inodes: regular files, directories,
 symbolic links, device nodes, etc. This feature is required for users wanting to use extended security
 facilities like POSIX ACLs or SELinux.
@@ -167,7 +167,7 @@ quota-tools package for more details.
 
 .TP
 \fBindexed-dirs\fR
-Enable directory indexing support. With this feature enabled, the file system creates indexed tree for non-inline directory entries. For large scale directories, directory entry lookup perfromance from the indexed tree is faster then from the legacy directory blocks.
+Enable directory indexing support. With this feature enabled, the file system creates indexed tree for non-inline directory entries. For large scale directories, directory entry lookup performance from the indexed tree is faster then from the legacy directory blocks.
 
 .TP
 \fBdiscontig-bg\fR

--- a/mounted.ocfs2/mounted.c
+++ b/mounted.ocfs2/mounted.c
@@ -569,7 +569,7 @@ int main(int argc, char **argv)
 
 	ret = build_partition_list(&dev_list, device);
 	if (ret) {
-		com_err(progname, ret, "while building partiton list");
+		com_err(progname, ret, "while building partition list");
 		goto bail;
 	}
 

--- a/o2cb_ctl/ocfs2.cluster.conf.5.in
+++ b/o2cb_ctl/ocfs2.cluster.conf.5.in
@@ -18,7 +18,7 @@ allows only one cluster to be active at any one time. The name of this active cl
 in /etc/sysconfig/o2cb [\fBo2cb.sysconfig(5)\fR].
 
 The \fBcluster stanza\fR specifies the name of the cluster, number of nodes and the heartbeat mode.
-The cluster name can include upto 16 alphanumeric characters [0-9A-Za-z]. No special characters
+The cluster name can include up to 16 alphanumeric characters [0-9A-Za-z]. No special characters
 are allowed.
 
 .TS
@@ -28,7 +28,7 @@ LB L.
 Parameters	Description
 node_count	Number of nodes in the cluster
 heartbeat_mode	\fBlocal\fR or \fBglobal\fR heartbeat
-name	Cluster name (upto 16 alphanumeric chars [0-9A-Za-z])
+name	Cluster name (up to 16 alphanumeric chars [0-9A-Za-z])
 .TE
 .BR
 
@@ -54,7 +54,7 @@ cluster	Cluster name (should match the name in the cluster stanza)
 .BR
 
 The \fBheartbeat stanza\fR specifies the global heartbeat region UUIDs. A cluster can have
-upto 32 heartbeat regions. This is an optional stanza and is only required if the global
+up to 32 heartbeat regions. This is an optional stanza and is only required if the global
 heartbeat mode is enabled. In other words, the regions are only used if \fBheartbeat_mode = global\fR
 is in the \fIcluster\fR stanza. If not, this stanza is ignored.
 

--- a/o2info/o2info.1.in
+++ b/o2info/o2info.1.in
@@ -7,9 +7,9 @@ o2info \- Show \fIOCFS2\fR file system information.
 .SH "DESCRIPTION"
 .PP
 \fBo2info\fR shows information about \fIOCFS2\fR file systems. It differs from \fBdebugfs.ocfs2(8)\fR
-in that it allows users with limited read priviledges to query similar information. Users do not have
+in that it allows users with limited read privileges to query similar information. Users do not have
 to have the read privilege on the device as is expected by \fBdebugfs.ocfs2(8)\fR. This utility allows
-users to provide a path to an object on a mounted file system. The user needs to have the read priviledge
+users to provide a path to an object on a mounted file system. The user needs to have the read privilege
 on that object.
 
 .SH "OPTIONS"
@@ -66,7 +66,7 @@ info ioctls were added starting in Linux kernel 2.6.37, this utility will not wo
 
 .SH "EXAMPLES"
 .PP
-Non-priviledged users can query the volume information by providing the path to a file on
+Non-privileged users can query the volume information by providing the path to a file on
 a mounted file system. Priviledged users can provide the path to the device.
 
 .in +4n

--- a/tunefs.ocfs2/feature_indexed_dirs.c
+++ b/tunefs.ocfs2/feature_indexed_dirs.c
@@ -62,7 +62,7 @@ static errcode_t build_dx_dir(ocfs2_filesys *fs, struct ocfs2_dinode *di,
 		ret = ocfs2_dx_dir_truncate(fs, di->i_blkno);
 		if (ret) {
 			ret = TUNEFS_ET_DX_DIRS_TRUNCATE_FAILED;
-			tcom_err(ret, "while rebulid indexed tree");
+			tcom_err(ret, "while rebuild indexed tree");
 		}
 	}
 

--- a/tunefs.ocfs2/feature_quota.c
+++ b/tunefs.ocfs2/feature_quota.c
@@ -108,7 +108,7 @@ static errcode_t create_quota_files(ocfs2_filesys *fs, int type,
 
 	ret = ocfs2_init_global_quota_file(fs, type);
 	if (ret) {
-		tcom_err(ret, "while initilizing global %s quota files",
+		tcom_err(ret, "while initializing global %s quota files",
 			 type2name(type));
 		return ret;
 	}
@@ -118,7 +118,7 @@ static errcode_t create_quota_files(ocfs2_filesys *fs, int type,
 		 type2name(type));
 	ret = ocfs2_init_local_quota_files(fs, type);
 	if (ret) {
-		tcom_err(ret, "while initilizing local %s quota files",
+		tcom_err(ret, "while initializing local %s quota files",
 			 type2name(type));
 		return ret;
 	}

--- a/tunefs.ocfs2/o2cluster.8.in
+++ b/tunefs.ocfs2/o2cluster.8.in
@@ -20,7 +20,7 @@ during which another node could mount the file system using the older cluster st
 If a dirty journal is detected, it implies one of two scenarios. Either the file system is
 mounted on another node, or, the last node to have it mounted, crashed. There is no way, short
 of joining the cluster, that the utility can use to differentiate between the two. Considering
-this utility is targetted to be used in scenarios when the user is looking to change the
+this utility is targeted to be used in scenarios when the user is looking to change the
 on-disk cluster stack, it becomes a chicken-and-egg problem.
 
 If one were to run into this scenario, the user should manually re-confirm that the file system
@@ -35,7 +35,7 @@ stack name, the cluster name and the cluster flags separated by commas. Like \fB
 
 The valid stack names are \fBo2cb\fR, \fBpcmk\fR, and \fBcman\fR.
 
-The cluster name can be upto 16 characters. The \fIo2cb\fR stack further restricts the names to
+The cluster name can be up to 16 characters. The \fIo2cb\fR stack further restricts the names to
 contain only alphanumeric characters.
 
 The valid flags for the \fIo2cb\fR stack are \fBlocal\fR and \fBglobal\fR, denoting the two heartbeat

--- a/tunefs.ocfs2/o2cluster.c
+++ b/tunefs.ocfs2/o2cluster.c
@@ -66,7 +66,7 @@ static void usage(int rc)
 
 	verbosef(VL_OUT, "Valid stack names are \"o2cb\", \"pcmk\" and \"cman\".\n\n");
 
-	verbosef(VL_OUT, "Cluster names can be upto 16 characters. The o2cb stack further restricts\n");
+	verbosef(VL_OUT, "Cluster names can be up to 16 characters. The o2cb stack further restricts\n");
 	verbosef(VL_OUT, "the names to contain only alphanumeric characters.\n\n");
 
 	verbosef(VL_OUT, "For the o2cb stack, valid flags are \"local\" and \"global\" denoting the two\n");

--- a/vendor/common/o2cb.sysconfig.5.in
+++ b/vendor/common/o2cb.sysconfig.5.in
@@ -24,7 +24,7 @@ supported by the same file system.
 \fBO2CB_BOOTCLUSTER\fR
 Name of the active cluster. While /etc/ocfs2/cluster.conf can hold descriptions of
 multiple clusters, only one can be active at any one time. The name of that
-active cluster is specified here. The name itself can be upto 16 alphanumeric
+active cluster is specified here. The name itself can be up to 16 alphanumeric
 characters [0-9A-Za-z] with no special characters.
 .PP
 


### PR DESCRIPTION
Spelling errors reported by lintian check of the
Debian package.