### PR TITLE
Fix build with glibc 2.28

### DIFF
--- a/debugfs.ocfs2/dump_fs_locks.c
+++ b/debugfs.ocfs2/dump_fs_locks.c
@@ -24,6 +24,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <sys/types.h>

--- a/extras/check_metaecc.c
+++ b/extras/check_metaecc.c
@@ -21,6 +21,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/find_allocation_fragments.c
+++ b/extras/find_allocation_fragments.c
@@ -25,6 +25,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <unistd.h>

--- a/extras/find_dup_extents.c
+++ b/extras/find_dup_extents.c
@@ -28,6 +28,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/find_hardlinks.c
+++ b/extras/find_hardlinks.c
@@ -28,6 +28,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/find_inode_paths.c
+++ b/extras/find_inode_paths.c
@@ -29,6 +29,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/mark_journal_dirty.c
+++ b/extras/mark_journal_dirty.c
@@ -25,6 +25,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/resize_slotmap.c
+++ b/extras/resize_slotmap.c
@@ -21,6 +21,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/extras/set_random_bits.c
+++ b/extras/set_random_bits.c
@@ -27,6 +27,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/fsck.ocfs2/dirblocks.c
+++ b/fsck.ocfs2/dirblocks.c
@@ -22,6 +22,7 @@
  * Just a simple rbtree wrapper to record directory blocks and the inodes
  * that own them.
  */
+#define _DEFAULT_SOURCE
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/ocfs2/ocfs2.h
+++ b/include/ocfs2/ocfs2.h
@@ -30,6 +30,9 @@
 #ifndef _XOPEN_SOURCE
 # define _XOPEN_SOURCE 600
 #endif
+#ifndef _DEFAULT_SOURCE
+# define _DEFAULT_SOURCE // for loff_t, needed for glibc >= 2.28
+#endif
 #ifndef _LARGEFILE64_SOURCE
 # define _LARGEFILE64_SOURCE
 #endif

--- a/libo2cb/o2cb_abi.c
+++ b/libo2cb/o2cb_abi.c
@@ -18,6 +18,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <inttypes.h>

--- a/libocfs2/alloc.c
+++ b/libocfs2/alloc.c
@@ -24,6 +24,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/bitmap.c
+++ b/libocfs2/bitmap.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/blockcheck.c
+++ b/libocfs2/blockcheck.c
@@ -22,6 +22,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #ifdef DEBUG_EXE

--- a/libocfs2/blocktype.c
+++ b/libocfs2/blocktype.c
@@ -19,6 +19,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/cached_inode.c
+++ b/libocfs2/cached_inode.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/chain.c
+++ b/libocfs2/chain.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/chainalloc.c
+++ b/libocfs2/chainalloc.c
@@ -24,6 +24,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/dir_iterate.c
+++ b/libocfs2/dir_iterate.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <inttypes.h>

--- a/libocfs2/dirblock.c
+++ b/libocfs2/dirblock.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/expanddir.c
+++ b/libocfs2/expanddir.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdio.h>

--- a/libocfs2/extend_file.c
+++ b/libocfs2/extend_file.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/extent_map.c
+++ b/libocfs2/extent_map.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/extents.c
+++ b/libocfs2/extents.c
@@ -27,6 +27,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/fileio.c
+++ b/libocfs2/fileio.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/freefs.c
+++ b/libocfs2/freefs.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdlib.h>

--- a/libocfs2/image.c
+++ b/libocfs2/image.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdio.h>

--- a/libocfs2/inode.c
+++ b/libocfs2/inode.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/inode_scan.c
+++ b/libocfs2/inode_scan.c
@@ -22,6 +22,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/link.c
+++ b/libocfs2/link.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/lookup.c
+++ b/libocfs2/lookup.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/memory.c
+++ b/libocfs2/memory.c
@@ -27,6 +27,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/mkjournal.c
+++ b/libocfs2/mkjournal.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/namei.c
+++ b/libocfs2/namei.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdio.h>

--- a/libocfs2/openfs.c
+++ b/libocfs2/openfs.c
@@ -26,6 +26,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/refcount.c
+++ b/libocfs2/refcount.c
@@ -19,6 +19,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/slot_map.c
+++ b/libocfs2/slot_map.c
@@ -19,6 +19,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include "ocfs2/byteorder.h"

--- a/libocfs2/sysfile.c
+++ b/libocfs2/sysfile.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/truncate.c
+++ b/libocfs2/truncate.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/libocfs2/unlink.c
+++ b/libocfs2/unlink.c
@@ -27,6 +27,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <string.h>

--- a/o2image/o2image.c
+++ b/o2image/o2image.c
@@ -23,6 +23,7 @@
  */
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
+#define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 
 #include <stdio.h>


### PR DESCRIPTION
Since glibc git 663e7d78 (to be 2.28), type loff_t will be only defined
when _DEFAULT_SOURCE defined. And with _XOPEN_SOURCE defined, _DEFAULT_SOURCE
will not be defined by default.

Without this fix, build failed with

make[1]: Entering directory '/builddir/build/BUILD/ocfs2-tools-ocfs2-tools-1.8.5/libo2cb'
gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -mcet -fcf-protection -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -pipe -fPIC    -I../include -I.  -DHAVE_CMAP -DHAVE_FSDLM  -MD -MP -MF ./.o2cb_abi.d -o o2cb_abi.o -c o2cb_abi.c
In file included from o2cb_abi.c:52:
../include/ocfs2/ocfs2.h:222:2: error: unknown type name 'loff_t'
  loff_t d_off; /* Offset of structure in the file */
  ^~~~~~

Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>