### PR TITLE
Define _DEFAULT_SOURCE to get loff_t

### DIFF
--- a/debugfs.ocfs2/dump_fs_locks.c
+++ b/debugfs.ocfs2/dump_fs_locks.c
@@ -25,6 +25,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/extras/check_metaecc.c
+++ b/extras/check_metaecc.c
@@ -22,6 +22,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/compute_groups.c
+++ b/extras/compute_groups.c
@@ -25,6 +25,8 @@
  * Authors: Tao Ma
  */
 
+#define _DEFAULT_SOURCE
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/extras/find_allocation_fragments.c
+++ b/extras/find_allocation_fragments.c
@@ -26,6 +26,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <unistd.h>
 

--- a/extras/find_dup_extents.c
+++ b/extras/find_dup_extents.c
@@ -29,6 +29,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/find_hardlinks.c
+++ b/extras/find_hardlinks.c
@@ -29,6 +29,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/find_inode_paths.c
+++ b/extras/find_inode_paths.c
@@ -30,6 +30,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/mark_journal_dirty.c
+++ b/extras/mark_journal_dirty.c
@@ -26,6 +26,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/resize_slotmap.c
+++ b/extras/resize_slotmap.c
@@ -22,6 +22,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <string.h>

--- a/extras/set_random_bits.c
+++ b/extras/set_random_bits.c
@@ -28,6 +28,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 #include <getopt.h>

--- a/libo2cb/o2cb_abi.c
+++ b/libo2cb/o2cb_abi.c
@@ -19,6 +19,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <inttypes.h>
 #include <string.h>

--- a/libocfs2/alloc.c
+++ b/libocfs2/alloc.c
@@ -25,6 +25,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/bitmap.c
+++ b/libocfs2/bitmap.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <limits.h>

--- a/libocfs2/blockcheck.c
+++ b/libocfs2/blockcheck.c
@@ -23,6 +23,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #ifdef DEBUG_EXE
 # define _BSD_SOURCE  /* For timersub() */

--- a/libocfs2/blocktype.c
+++ b/libocfs2/blocktype.c
@@ -20,6 +20,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/cached_inode.c
+++ b/libocfs2/cached_inode.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/chain.c
+++ b/libocfs2/chain.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/chainalloc.c
+++ b/libocfs2/chainalloc.c
@@ -25,6 +25,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/closefs.c
+++ b/libocfs2/closefs.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include "ocfs2/ocfs2.h"
 

--- a/libocfs2/dir_iterate.c
+++ b/libocfs2/dir_iterate.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <inttypes.h>
 

--- a/libocfs2/dirblock.c
+++ b/libocfs2/dirblock.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/dlm.c
+++ b/libocfs2/dlm.c
@@ -25,6 +25,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include "ocfs2/ocfs2.h"
 

--- a/libocfs2/expanddir.c
+++ b/libocfs2/expanddir.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <string.h>

--- a/libocfs2/extend_file.c
+++ b/libocfs2/extend_file.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #if HAVE_UNISTD_H

--- a/libocfs2/extent_map.c
+++ b/libocfs2/extent_map.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/extents.c
+++ b/libocfs2/extents.c
@@ -28,6 +28,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/feature_string.c
+++ b/libocfs2/feature_string.c
@@ -23,6 +23,8 @@
  *
  */
 
+#define _DEFAULT_SOURCE
+
 #include "ocfs2/ocfs2.h"
 
 struct fs_feature_flags {

--- a/libocfs2/fileio.c
+++ b/libocfs2/fileio.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <limits.h>

--- a/libocfs2/freefs.c
+++ b/libocfs2/freefs.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdlib.h>
 

--- a/libocfs2/image.c
+++ b/libocfs2/image.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <unistd.h>

--- a/libocfs2/inode.c
+++ b/libocfs2/inode.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/inode_scan.c
+++ b/libocfs2/inode_scan.c
@@ -23,6 +23,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <stdlib.h>

--- a/libocfs2/link.c
+++ b/libocfs2/link.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/lookup.c
+++ b/libocfs2/lookup.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/memory.c
+++ b/libocfs2/memory.c
@@ -28,6 +28,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <stdlib.h>

--- a/libocfs2/mkjournal.c
+++ b/libocfs2/mkjournal.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <netinet/in.h>

--- a/libocfs2/namei.c
+++ b/libocfs2/namei.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <string.h>

--- a/libocfs2/openfs.c
+++ b/libocfs2/openfs.c
@@ -27,6 +27,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/refcount.c
+++ b/libocfs2/refcount.c
@@ -20,6 +20,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <inttypes.h>

--- a/libocfs2/slot_map.c
+++ b/libocfs2/slot_map.c
@@ -20,6 +20,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include "ocfs2/byteorder.h"
 #include "ocfs2/ocfs2.h"

--- a/libocfs2/sysfile.c
+++ b/libocfs2/sysfile.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600  /* Triggers XOPEN2K in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 

--- a/libocfs2/truncate.c
+++ b/libocfs2/truncate.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #if HAVE_UNISTD_H

--- a/libocfs2/unlink.c
+++ b/libocfs2/unlink.c
@@ -28,6 +28,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <string.h>
 #include <assert.h>

--- a/o2image/o2image.c
+++ b/o2image/o2image.c
@@ -24,6 +24,7 @@
 
 #define _XOPEN_SOURCE 600 /* Triggers magic in features.h */
 #define _LARGEFILE64_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
Since glibc 2.28 either _DEFAULT_SOURCE or _GNU_SOURCE is required
to get loff_t defined again.

In file included from o2cb_abi.c:52:
../include/ocfs2/ocfs2.h:222:2: error: unknown type name 'loff_t'
  loff_t d_off; /* Offset of structure in the file */
  ^~~~~~