### PR TITLE
Fix format string truncation

### DIFF
--- a/libtools-internal/scandisk.c
+++ b/libtools-internal/scandisk.c
@@ -548,7 +548,7 @@ static int sysfs_is_dev(char *path, int *maj, int *min)
 	char newpath[MAXPATHLEN];
 	struct stat sb;
 	FILE *f;
-	snprintf(newpath, sizeof(newpath), "%s/dev", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/dev", (int)sizeof(newpath) - 5, path);
 	if (!lstat(newpath, &sb)) {
 		f = fopen(newpath, "r");
 		if (f) {
@@ -581,7 +581,7 @@ static int sysfs_is_removable(char *path)
 	struct stat sb;
 	int i = -1;
 	FILE *f;
-	snprintf(newpath, sizeof(newpath), "%s/removable", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/removable", (int)sizeof(newpath) - 11, path);
 	if (!lstat(newpath, &sb)) {
 		f = fopen(newpath, "r");
 		if (f) {
@@ -652,27 +652,27 @@ static int sysfs_is_disk(char *path)
 	int i = -1;
 	FILE *f;
 
-	snprintf(newpath, sizeof(newpath), "%s/device/type", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/device/type", (int)sizeof(newpath) - 13, path);
 	if (!lstat(newpath, &sb))
 		goto found;
 
-	snprintf(newpath, sizeof(newpath), "%s/../device/type", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/../device/type", (int)sizeof(newpath) - 16, path);
 	if (!lstat(newpath, &sb))
 		goto found;
 
-	snprintf(newpath, sizeof(newpath), "%s/device/media", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/device/media", (int)sizeof(newpath) - 14, path);
 	if (!lstat(newpath, &sb))
 		goto found;
 
-	snprintf(newpath, sizeof(newpath), "%s/../device/media", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/../device/media", (int)sizeof(newpath) - 17, path);
 	if (!lstat(newpath, &sb))
 		goto found;
 
-	snprintf(newpath, sizeof(newpath), "%s/device/devtype", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/device/devtype", (int)sizeof(newpath) - 16, path);
 	if (!lstat(newpath, &sb))
 		return 1;
 
-	snprintf(newpath, sizeof(newpath), "%s/../device/devtype", path);
+	snprintf(newpath, sizeof(newpath), "%.*s/../device/devtype", (int)sizeof(newpath) - 19, path);
 	if (!lstat(newpath, &sb))
 		return 1;
 

--- a/mount.ocfs2/sundries.c
+++ b/mount.ocfs2/sundries.c
@@ -249,7 +249,7 @@ canonicalize_dm_name(const char *ptname)
 	sz = strlen(name);
 	if (s && sz > 1) {
 		name[sz - 1] = '\0';
-		snprintf(path, sizeof(path), "/dev/mapper/%s", name);
+		snprintf(path, sizeof(path), "/dev/mapper/%.*s", (int)sizeof(path) - 13, name);
 		res = strdup(path);
 	}
 	fclose(f);

--- a/tunefs.ocfs2/op_list_sparse_files.c
+++ b/tunefs.ocfs2/op_list_sparse_files.c
@@ -404,7 +404,7 @@ static errcode_t list_sparse(ocfs2_filesys *fs)
 		ctxt.fs = fs;
 		ctxt.multi_link_files = RB_ROOT;
 		ctxt.func = list_sparse_iterate;
-		sprintf(ctxt.file_name, "%s/", file_name);
+		sprintf(ctxt.file_name, "%.*s/", (int)sizeof(ctxt.file_name) - 2, file_name);
 		ctxt.file_name_len = strlen(ctxt.file_name);
 		ret = ocfs2_dir_iterate(fs, blkno,
 					OCFS2_DIRENT_FLAG_EXCLUDE_DOTS,


### PR DESCRIPTION
Warning reported by GCC 8.3.0:

scandisk.c: In function 'scansysfs':
scandisk.c:551:40: warning: '/dev' directive output may be truncated writing 4 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
  snprintf(newpath, sizeof(newpath), "%s/dev", path);
                                        ^~~~