### PR TITLE
fix#18

### DIFF
--- a/Preamble.make
+++ b/Preamble.make
@@ -28,7 +28,7 @@ DIST_RULES =
 INCLUDES =
 DEFINES = 
 
-CFLAGS += -pipe -D_DEFAULT_SOURCE=1
+CFLAGS += -pipe -Wno-format-security -D_DEFAULT_SOURCE=1
 # protect with configure?
 CDEPFLAGS = -MD -MP -MF $(@D)/.$(basename $(@F)).d
 


### PR DESCRIPTION
Signed-off-by: gaosong <gaosong@htzg.com>
-Wformat-security  is  enabled by default for C, C++, ObjC   on  high version GCC or high version system.   To disable, use -Wno-format-security.  