### PR TITLE
o2image: Fix segfault on s390x

### DIFF
--- a/o2image/o2image.c
+++ b/o2image/o2image.c
@@ -113,7 +113,7 @@ static errcode_t traverse_extents(ocfs2_filesys *ofs,
 			if (ret)
 				goto out;
 		} else {
-			for (j = 0; j < (rec->e_int_clusters*ost->ost_bpc); j++)
+			for (j = 0; j < (rec->e_leaf_clusters*ost->ost_bpc); j++)
 				ocfs2_image_mark_bitmap(ofs,
 							(rec->e_blkno + j));
 		}


### PR DESCRIPTION
Use correct union member. On little endian this worked only because of the union layout.

Fixes #22 o2image fails on s390x (big endian)

Signed-off-by: Valentin Vidic <vvidic@debian.org>