### PR TITLE
Fixed `mounted.ocfs2` output when some devices are Not Ready

### DIFF
--- a/mounted.ocfs2/mounted.c
+++ b/mounted.ocfs2/mounted.c
@@ -530,7 +530,7 @@ static void do_quick_detect(struct list_head *dev_list)
 
 		for (offset = 1; offset <= 8; offset <<= 1) {
 			ret = do_pread(fd, buf, sizeof(buf), (offset * 1024));
-			if (ret < (int) sizeof(buf))
+			if (ret == -1 || ret != sizeof(buf))
 				break;
 			di = (struct ocfs2_dinode *)buf;
 			if (!memcmp(di->i_signature,


### PR DESCRIPTION
When `mounted.ocfs2 -d` (quick scan) encounters a device in Not Ready state, it tries to read the device, fails, and in theory should skip it and proceed to the next one. However, due to an integer comparison with mixed signedness it does not break out of the read loop when `do_pread` returns an error code (-1), and fills the structure for current file system with the data that is left in the buffer from the previous file system.

In such conditions, the command produces the following output:
```
# these two devices are working
/dev/mapper/360000970000197600444533037353334_part1 pcmk hacluster B9223C9922754CE88236EDDE6B281D15 ALPHA
/dev/mapper/360000970000197600444533037353335_part1 pcmk hacluster ACAC4B66517D4EDEA6FA8A9D8E9FC9CF BETA
# these two are not ready
/dev/mapper/360000970000197600444533037423031       pcmk hacluster ACAC4B66517D4EDEA6FA8A9D8E9FC9CF BETA
/dev/mapper/360000970000197600444533037423032       pcmk hacluster ACAC4B66517D4EDEA6FA8A9D8E9FC9CF BETA
# this one is OK
/dev/mapper/360000970000197600444533037423030_part1 pcmk hacluster 7A0C73F5A4C04135874F307384D3F67E GAMMA
# these two are not ready again
/dev/mapper/360000970000197600444533037423033       pcmk hacluster 7A0C73F5A4C04135874F307384D3F67E GAMMA
/dev/mapper/360000970000197600444533037423034       pcmk hacluster 7A0C73F5A4C04135874F307384D3F67E GAMMA
```
Here, labels and UUIDs for offline devices are the same as for preceding active ones.

The fix converts the unsigned value returned by `sizeof` to signed integer explicitly.