### PR TITLE
dump_fs_locks: support v4

### DIFF
--- a/debugfs.ocfs2/dump_fs_locks.c
+++ b/debugfs.ocfs2/dump_fs_locks.c
@@ -225,13 +225,14 @@ static void dump_meta_lvb(const char *raw_lvb, FILE *out)
 }
 
 /* 0 = eof, > 0 = success, < 0 = error */
-static int dump_version_two_and_three(FILE *file, FILE *out, int v3)
+static int dump_version_two_or_more(FILE *file, FILE *out, int version)
 {
 	unsigned long long num_prmode, num_exmode;
 	unsigned int num_prmode_failed, num_exmode_failed;
 	unsigned long long  total_prmode, total_exmode;
 	unsigned long long  avg_prmode = 0, avg_exmode = 0;
 	unsigned int max_prmode, max_exmode, num_refresh;
+	unsigned long long  last_prmode, last_exmode, wait;
 	int ret;
 
 #define NSEC_PER_USEC   1000
@@ -244,7 +245,10 @@ static int dump_version_two_and_three(FILE *file, FILE *out, int v3)
 		     "%llu\t"
 		     "%u\t"
 		     "%u\t"
-		     "%u",
+		     "%u\t"
+		     "%llu\t"
+		     "%llu\t"
+		     "%llu",
 		     &num_prmode,
 		     &num_exmode,
 		     &num_prmode_failed,
@@ -253,13 +257,16 @@ static int dump_version_two_and_three(FILE *file, FILE *out, int v3)
 		     &total_exmode,
 		     &max_prmode,
 		     &max_exmode,
-		     &num_refresh);
-	if (ret != 9) {
+		     &num_refresh,
+		     &last_prmode,
+		     &last_exmode,
+		     &wait);
+	if (ret != 12) {
 		ret = -EINVAL;
 		goto out;
 	}
 
-	if (!v3) {
+	if (version < 3) {
 		max_prmode /= NSEC_PER_USEC;
 		max_exmode /= NSEC_PER_USEC;
 	}
@@ -271,14 +278,26 @@ static int dump_version_two_and_three(FILE *file, FILE *out, int v3)
 		avg_exmode = total_exmode/num_exmode;
 
 	fprintf(out, "PR > Gets: %llu  Fails: %u    Waits Total: %lluus  "
-		"Max: %uus  Avg: %lluns\n",
+		"Max: %uus  Avg: %lluns",
 		num_prmode, num_prmode_failed, total_prmode/NSEC_PER_USEC,
 		max_prmode, avg_prmode);
+	if (version > 3) {
+		fprintf(out, " Last: %lluus", last_prmode);
+	}
+	fprintf(out, "\n");
 	fprintf(out, "EX > Gets: %llu  Fails: %u    Waits Total: %lluus  "
-		"Max: %uus  Avg: %lluns\n",
+		"Max: %uus  Avg: %lluns",
 		num_exmode, num_exmode_failed, total_exmode/NSEC_PER_USEC,
 		max_exmode, avg_exmode);
-	fprintf(out, "Disk Refreshes: %u\n", num_refresh);
+	if (version > 3) {
+		fprintf(out, " Last: %lluus", last_exmode);
+	}
+	fprintf(out, "\n");
+	fprintf(out, "Disk Refreshes: %u", num_refresh);
+	if (version > 3) {
+		fprintf(out, " First Wait: %lluus", wait);
+	}
+	fprintf(out, "\n");
 
 	ret = 1;
 out:
@@ -388,13 +407,13 @@ static int end_line(FILE *f)
 	return 0;
 }
 
-#define CURRENT_PROTO 3
+#define CURRENT_PROTO 4
 /* returns 0 on error or end of file */
 static int dump_one_lockres(FILE *file, FILE *out, int lvbs, int only_busy,
 			    struct list_head *locklist)
 {
 	unsigned int version;
-	int ret, v3;
+	int ret;
 	int skipped = 0;
 
 	ret = fscanf(file, "%x\t", &version);
@@ -413,8 +432,7 @@ static int dump_one_lockres(FILE *file, FILE *out, int lvbs, int only_busy,
 
 	if (!skipped) {
 		if (version > 1) {
-			v3 = !!(version == 3);
-			ret = dump_version_two_and_three(file, out, v3);
+			ret = dump_version_two_or_more(file, out, version);
 			if (ret <= 0)
 				return 0;
 		}


### PR DESCRIPTION
3 years ago, the kernel implementation added 4:
https://github.com/torvalds/linux/commit/8a7f5f4c26dd4e969b5f3b30d06c54dc6a520eda#diff-763516839c283f4678cde681fcdba36b4f99f41ad05087b4ee3d8cf569680171

So dump_fs_locks doesnt work against that and fails due to the version being higher than expected.
