### PR TITLE
debugfs.ocfs2: support recording gd bg_contig_free_bits

### DIFF
--- a/debugfs.ocfs2/debugfs.ocfs2.8.in
+++ b/debugfs.ocfs2/debugfs.ocfs2.8.in
@@ -189,6 +189,12 @@ contents of the lock value block and \fI-f <file>\fR to specify a
 saved copy of /sys/kernel/debug/ocfs2/<UUID>/locking_state.
 
 .TP
+\fIgd_free_bits [-s]\fR
+Display the contiguous free bits of group descriptor blocks which are
+managed by //global_bitmap. \fI-s\fR to record contiguous free bits
+in group descriptor block. The [-s] option requires debugfs.ocfs2 option \fI-w\fR.
+
+.TP
 \fIgroup <block#>\fR
 Display the contents of the group descriptor at \fIblock#\fR.
 

--- a/debugfs.ocfs2/dump.c
+++ b/debugfs.ocfs2/dump.c
@@ -490,6 +490,34 @@ void dump_group_descriptor(FILE *out, struct ocfs2_group_desc *grp, int index)
 	return ;
 }
 
+/* copy from dump_group_descriptor() */
+void dump_gd_free_bits(FILE *out, struct ocfs2_group_desc *grp, int index)
+{
+	int max_contig_free_bits = 0;
+
+	if (!index) {
+		fprintf(out, "\tGroup Chain: %u   Parent Inode: %"PRIu64"  "
+			 "Generation: %u\n",
+			 grp->bg_chain,
+			 (uint64_t)grp->bg_parent_dinode,
+			 grp->bg_generation);
+		dump_block_check(out, &grp->bg_check, grp);
+
+		fprintf(out, "\t##   %-15s   %-6s   %-6s   %-6s   %-6s   %-6s   %-6s\n",
+			"Block#", "Total", "Used", "Free", "Contig", "Disk-contig", "Size");
+	}
+
+	find_max_contig_free_bits(grp, &max_contig_free_bits);
+
+	fprintf(out, "\t%-2d   %-15"PRIu64"   %-6u   %-6u   %-6u   %-6u   %-11u   %-6u\n",
+		index, (uint64_t)grp->bg_blkno, grp->bg_bits,
+		(grp->bg_bits - grp->bg_free_bits_count),
+		grp->bg_free_bits_count, max_contig_free_bits,
+		grp->bg_contig_free_bits, grp->bg_size);
+
+	return ;
+}
+
 void dump_group_extents(FILE *out, struct ocfs2_group_desc *grp)
 {
 	fprintf(out, "\tGroup# %"PRIu64"   Total: %u   Used: %u   Free: %u\n",

--- a/debugfs.ocfs2/include/dump.h
+++ b/debugfs.ocfs2/include/dump.h
@@ -42,6 +42,7 @@ void dump_extent_list (FILE *out, struct ocfs2_extent_list *ext);
 void dump_chain_list (FILE *out, struct ocfs2_chain_list *cl);
 void dump_extent_block (FILE *out, struct ocfs2_extent_block *blk);
 void dump_group_descriptor (FILE *out, struct ocfs2_group_desc *grp, int index);
+void dump_gd_free_bits (FILE *out, struct ocfs2_group_desc *grp, int index);
 void dump_group_extents(FILE *out, struct ocfs2_group_desc *grp);
 int  dump_dir_entry (struct ocfs2_dir_entry *rec, uint64_t blocknr, int offset, int blocksize,
 		     char *buf, void *priv_data);

--- a/debugfs.ocfs2/include/utils.h
+++ b/debugfs.ocfs2/include/utils.h
@@ -37,6 +37,12 @@ struct strings {
 	struct list_head s_list;
 };
 
+enum ocfs2_traverse_chains_action {
+	DUMP_GD = 0,
+	DUMP_GD_FREE_BITS,
+	RECORD_GD_FREE_BITS,
+};
+
 void get_incompat_flag(struct ocfs2_super_block *sb, char *buf, size_t count);
 void get_tunefs_flag(struct ocfs2_super_block *sb, char *buf, size_t count);
 void get_compat_flag(struct ocfs2_super_block *sb, char *buf, size_t count);
@@ -78,7 +84,7 @@ int del_from_stringlist(char *str, struct list_head *strlist);
 errcode_t traverse_extents(ocfs2_filesys *fs, struct ocfs2_extent_list *el,
 			   FILE *out);
 errcode_t traverse_chains(ocfs2_filesys *fs, struct ocfs2_chain_list *cl,
-			  FILE *out);
+			  FILE *out, enum ocfs2_traverse_chains_action action);
 
 enum dump_block_type detect_block (char *buf);
 

--- a/debugfs.ocfs2/stat_sysdir.c
+++ b/debugfs.ocfs2/stat_sysdir.c
@@ -64,7 +64,7 @@ static int show_system_inode(struct ocfs2_dir_entry *rec, uint64_t blocknr,
 	if ((di->i_flags & OCFS2_LOCAL_ALLOC_FL))
 		dump_local_alloc(out, &(di->id2.i_lab));
 	else if ((di->i_flags & OCFS2_CHAIN_FL))
-		ret = traverse_chains(fs, &(di->id2.i_chain), out);
+		ret = traverse_chains(fs, &(di->id2.i_chain), out, DUMP_GD);
 	else if (S_ISLNK(di->i_mode) && !di->i_clusters)
 		dump_fast_symlink(out, (char *)di->id2.i_symlink);
 	else if (di->i_flags & OCFS2_DEALLOC_FL)

--- a/include/ocfs2-kernel/ocfs2_fs.h
+++ b/include/ocfs2-kernel/ocfs2_fs.h
@@ -934,7 +934,8 @@ struct ocfs2_group_desc
 	__le16	bg_free_bits_count;     /* Free bits count */
 	__le16   bg_chain;               /* What chain I am in. */
 /*10*/	__le32   bg_generation;
-	__le32	bg_reserved1;
+	__le16   bg_contig_free_bits;   /* max contig free bits length */
+	__le16   bg_reserved1;
 	__le64   bg_next_group;          /* Next group in my list, in
 					   blocks */
 /*20*/	__le64   bg_parent_dinode;       /* dinode which owns me, in


### PR DESCRIPTION
This commit introduces new feature for debugfs.ocfs2, which could record contiguous free bits for each //global_bitmap group descriptor block.

It's very useful for the users who want to speed up IO performance, when ocfs2 volume fragmentation rate is high.

Please note, this commit requires kernel supporting 'struct ocfs2_group_desc' new member 'bg_contig_free_bits'.