### PR TITLE
o2cb.init: remove unwanted legacy /etc/init.d/functions

### DIFF
--- a/vendor/common/o2cb.init.sh
+++ b/vendor/common/o2cb.init.sh
@@ -20,8 +20,10 @@ export LC_ALL=C
 
 if [ -f /etc/redhat-release ]
 then
-. /etc/init.d/functions
-
+    if [ -f /etc/init.d/functions ]
+    then
+        . /etc/init.d/functions
+    fi
 start_daemon () {
     daemon  $*
 }


### PR DESCRIPTION
This is causing an ENOENT error message in o2cb.init even though everything works just fine. The file /etc/init.d/functions has been removed from the distros long ago. Removing the unwanted legacy, non-existent references.